### PR TITLE
chore/coverage 85 threshold

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "node --test",
     "test:watch": "node --test --watch",
     "test:cov": "c8 --reporter=text --reporter=lcov npm test",
-    "test:cov:check": "c8 --check-coverage --branches 80 --functions 95 --lines 72 --statements 72 npm test",
+    "test:cov:check": "c8 --check-coverage --branches 85 --functions 95 --lines 72 --statements 72 npm test",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier -w .",


### PR DESCRIPTION
- **chore(ci): raise c8 branch coverage threshold to 85%**
- **test(api): cover top-level server catch on unknown route; branch coverage ~87%**
