### PR TITLE
test(coverage): raise c8 thresholds to lines/stmts 90, funcs 95, branches 87

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "node --test",
     "test:watch": "node --test --watch",
     "test:cov": "c8 --reporter=text --reporter=lcov npm test",
-    "test:cov:check": "c8 --check-coverage --branches 85 --functions 95 --lines 72 --statements 72 npm test",
+    "test:cov:check": "c8 --check-coverage --branches 87 --functions 95 --lines 90 --statements 90 npm test",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier -w .",


### PR DESCRIPTION
Eleva os thresholds de cobertura do c8 para alinhar com baseline atual (stmts/lines 98.52, funcs 100, branches 87.32). Gate passa localmente e no CI. CODECOV_TOKEN e App configurados já garantem upload no Node 24.x.