### PR TITLE
ci(codecov): comment tuning (require_changes, require_head)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,6 +6,9 @@ codecov:
 comment:
   layout: "reach, diff, flags, files"
   behavior: default
+  require_changes: true
+  require_base: false
+  require_head: true
 coverage:
   precision: 2
   round: down


### PR DESCRIPTION
Personaliza comentários do Codecov: require_changes=true, require_head=true, require_base=false para reduzir ruído e garantir comentário apenas quando houver mudança de cobertura e head report.